### PR TITLE
Add validate schedule on start

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,10 @@ func main() {
 	}
 	log.Println("Running version:", version)
 
-	c, wg := gocron.Create(*schedule, execArgs[0], execArgs[1:len(execArgs)])
+	c, wg, err := gocron.Create(*schedule, execArgs[0], execArgs[1:len(execArgs)])
+	if err != nil {
+		log.Fatalf("Invalid schedule: %v", err)
+	}
 
 	go gocron.Start(c)
 	if *port != "0" {


### PR DESCRIPTION
I had the Issue that I surrounded the cron with `"` and it took me some time to find this error.

So I thought it would be a good addition to validate the supplied cron and return an error if it is not valid.

For example:

```
dist> .\go-cron-windows-amd64.exe -s "i * * * * *" -p 0 -- cmd.exe /C echo 1
2025/01/18 14:21:25 Running version:
2025/01/18 14:21:25 Invalid schedule: failed to parse int from i: strconv.Atoi: parsing "i": invalid syntax
```